### PR TITLE
added m.hentai2read.com and www.friendshipscans.com and fixed egscans.org

### DIFF
--- a/webcomic_reader.user.js
+++ b/webcomic_reader.user.js
@@ -3363,20 +3363,20 @@ var paginas = [
 	{	url:	'm.hentai2read.com',
 		img:	[['.prw img']],
 		back:	function(html, pos){
-					var baseurl = xpath('(//select[@class="cbo_wpm_chp"])/@onchange', html).replace(/^.*?'|'.*$/gi, '');
+					var baseurl = xpath('//select[@class="cbo_wpm_chp"]/@onchange', html).replace(/^.*?'|'.*$/gi, '');
 					try{
-						var pag = xpath('(//select[@class="cbo_wpm_pag"])/option[@selected]/preceding-sibling::option[1]/@value', html);
+						var pag = xpath('//select[@class="cbo_wpm_pag"]/option[@selected]/preceding-sibling::option[1]/@value', html);
 						var chap = selCss('select.cbo_wpm_chp > option[selected]', html).value;
 						return baseurl + chap +'/' + pag + '/';
 					}
 					catch(e){
-						var chap = xpath('(//select[@class="cbo_wpm_chp"])/option[@selected]/following-sibling::option[1]/@value', html);
+						var chap = xpath('//select[@class="cbo_wpm_chp"]/option[@selected]/following-sibling::option[1]/@value', html);
 						var htmlPrev = syncRequest(baseurl + chap +'/', pos);
-						var pag = xpath('(//select[@class="cbo_wpm_pag"])/option[last()]/@value', htmlPrev);
+						var pag = xpath('//select[@class="cbo_wpm_pag"]/option[last()]/@value', htmlPrev);
 						return baseurl + chap +'/' + pag + '/';
 					}
 				},
-		next:	['//img[@class="cmd" and @alt="Next Page"]/..[starts-with(@href,"http")]'],
+		next:	['//img[contains(concat(" ",@class," ")," cmd ") and @alt="Next Page" and starts-with(../@href,"http")]/..'],
 		extra:	['<span style="float:left">Chapter ', [['.cbo_wpm_chp']], '</span><span style="float:right">Page ', [['.cbo_wpm_pag']], '</span><span class="clr"></span>'],
 		style:	'.header{position:relative;} .content-box{padding-top:20px;} #wcr_imagen{max-width:none;} .prw{overflow:visible !important;} div.wpm_nav{display:none}',
 		scrollx:'R'


### PR DESCRIPTION
I added friendshipscans.com and m.hentai2read.com, which is just a different interface from the default hentai2read.com. 
You can just change the adress bar from hentai2read.com to m.hentai2read.com or vice versa and the site works properly. But since sometimes when you are viewing hentai2read.com the links sometimes point to m.hentai2read.com (I don't know if the reverse happens) I added a fixurl function to hentai2read.com for link pages. 

Important: The fixurl function runs properly at Chrome but never in Firefox. I even called alert(link) at the very beginning of the fixurl function, but in FF the alert box was never shown. Can you check why that happens?
